### PR TITLE
Avoid redownloading and filesystem clobbering

### DIFF
--- a/prepare-lecaa
+++ b/prepare-lecaa
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget https://d4twhgtvn0ff5.cloudfront.net/caa-rechecking-incident-affected-serials.txt.gz
+wget -c https://d4twhgtvn0ff5.cloudfront.net/caa-rechecking-incident-affected-serials.txt.gz
 
 zcat caa-rechecking-incident-affected-serials.txt.gz|sed -e 's:^serial ::g' -e 's: .*::g'|LANG=C sort -u > lecaa-serials.txt


### PR DESCRIPTION
Try to continue the download if it already exists. This also prevents wasting bandwidth for a file download that later one isn't used.