### PR TITLE
fix zcat for MacOS

### DIFF
--- a/prepare-lecaa
+++ b/prepare-lecaa
@@ -2,4 +2,4 @@
 
 wget -c https://d4twhgtvn0ff5.cloudfront.net/caa-rechecking-incident-affected-serials.txt.gz
 
-zcat caa-rechecking-incident-affected-serials.txt.gz|sed -e 's:^serial ::g' -e 's: .*::g'|LANG=C sort -u > lecaa-serials.txt
+zcat < caa-rechecking-incident-affected-serials.txt.gz|sed -e 's:^serial ::g' -e 's: .*::g'|LANG=C sort -u > lecaa-serials.txt


### PR DESCRIPTION
`zcat: can't stat: caa-rechecking-incident-affected-serials.txt.gz (caa-rechecking-incident-affected-serials.txt.gz.Z): No such file or directory`