### PR TITLE
Support non-standard ports

### DIFF
--- a/lecaa
+++ b/lecaa
@@ -1,6 +1,11 @@
 #!/bin/bash
+IN=$1:$2
+IFS=':'; arrIN=($IN); unset IFS;
+host=${arrIN[0]};
+port=${arrIN[1]};
+[ -z "$port" ] && port=443
 
-out=$(openssl s_client -connect $1:443 -servername $1 -showcerts </dev/null 2>/dev/null | openssl x509 -text -noout | grep -A 1 Serial\ Number | tr -d : | tail -n 1)
+out=$(openssl s_client -connect $host:$port -servername $host -showcerts </dev/null 2>/dev/null | openssl x509 -text -noout | grep -A 1 Serial\ Number | tr -d : | tail -n 1)
 
 look $out lecaa-serials.txt > /dev/null
 


### PR DESCRIPTION
Add ability to check certs on non-standard port. Supports two options:
  ./lecca host:port
  ./lecaa host port