### PR TITLE
make scripts more portable

### DIFF
--- a/lecaa
+++ b/lecaa
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IN=$1:$2
 IFS=':'; arrIN=($IN); unset IFS;

--- a/prepare-lecaa
+++ b/prepare-lecaa
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 wget -c https://d4twhgtvn0ff5.cloudfront.net/caa-rechecking-incident-affected-serials.txt.gz
 


### PR DESCRIPTION
Use `env` to start Bash, as not all systems where `bash` is available have it sitting at `/bin/bash`.

(Granted, also not all systems do have `/usr/bin/env`, either. But those who don't are few and far between and probably much rarer than those that have `bash` somewhere else than at `/bin/bash`.)